### PR TITLE
Create IntegrateAPI - About Mentoring Setting Functions

### DIFF
--- a/AccountAPI/src/main/java/net/skhu/mentoring/controller/AdminRestController.java
+++ b/AccountAPI/src/main/java/net/skhu/mentoring/controller/AdminRestController.java
@@ -57,6 +57,16 @@ public class AdminRestController {
         }
     }
 
+    @PutMapping("account/mentoring/{user}/{role}")
+    public ResponseEntity<?> executeApplicateMentoring(Principal principal, HttpServletRequest request, @PathVariable String user, @PathVariable String role){
+        return adminService.executeAppointMentoring(principal, request, user, role);
+    }
+
+    @PutMapping("account/student/reset")
+    public ResponseEntity<?> executeStudentStatusResetting(Principal principal, HttpServletRequest request){
+        return adminService.executeResettingStudentStatus(principal, request);
+    }
+
     @GetMapping("account/options/search_by")
     public ResponseEntity<?> fetchSearchByOptions(Principal principal, HttpServletRequest request){
         return ResponseEntity.ok(adminService.getSearchByModel(principal, request));

--- a/AccountAPI/src/main/java/net/skhu/mentoring/controller/ResourceRestController.java
+++ b/AccountAPI/src/main/java/net/skhu/mentoring/controller/ResourceRestController.java
@@ -2,8 +2,10 @@ package net.skhu.mentoring.controller;
 
 import net.skhu.mentoring.domain.Department;
 import net.skhu.mentoring.domain.Profile;
+import net.skhu.mentoring.model.MentoringModel;
 import net.skhu.mentoring.service.interfaces.ResourceService;
 import net.skhu.mentoring.vo.AvailableTimeVO;
+import net.skhu.mentoring.vo.BriefAccountVO;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
@@ -12,6 +14,8 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.CrossOrigin;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -62,6 +66,11 @@ public class ResourceRestController {
         else return ResponseEntity.noContent().build();
     }
 
+    @PostMapping("available_times")
+    public ResponseEntity<?> fetchMentoringAvailableTimes(@RequestBody MentoringModel mentoringModel){
+        return ResponseEntity.ok(resourceService.fetchEachMentoringAvailableTimes(mentoringModel));
+    }
+
     @GetMapping("profile/{identity}")
     public ResponseEntity<?> fetchEachProfile(@PathVariable String identity) {
         Profile profile = resourceService.fetchEachProfile(identity);
@@ -76,6 +85,13 @@ public class ResourceRestController {
     public ResponseEntity<String> fetchAccountNameByIdentity(@PathVariable String identity){
         String result = resourceService.fetchAccountNameByIdentity(identity);
         if(result != null) return ResponseEntity.ok(result);
+        else return ResponseEntity.noContent().build();
+    }
+
+    @GetMapping("account/brief/{identity}")
+    public ResponseEntity<BriefAccountVO> fetchBriefAccountInfo(@PathVariable String identity){
+        BriefAccountVO accountVO = resourceService.fetchBriefAccountInfoByIdentity(identity);
+        if(accountVO != null) return ResponseEntity.ok(accountVO);
         else return ResponseEntity.noContent().build();
     }
 }

--- a/AccountAPI/src/main/java/net/skhu/mentoring/model/MentoringModel.java
+++ b/AccountAPI/src/main/java/net/skhu/mentoring/model/MentoringModel.java
@@ -1,0 +1,15 @@
+package net.skhu.mentoring.model;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class MentoringModel {
+    private String mento;
+    private List<String> mentis;
+}

--- a/AccountAPI/src/main/java/net/skhu/mentoring/service/implement_objects/ResourceServiceImpl.java
+++ b/AccountAPI/src/main/java/net/skhu/mentoring/service/implement_objects/ResourceServiceImpl.java
@@ -3,18 +3,22 @@ package net.skhu.mentoring.service.implement_objects;
 import net.skhu.mentoring.domain.Account;
 import net.skhu.mentoring.domain.Department;
 import net.skhu.mentoring.domain.Profile;
+import net.skhu.mentoring.model.MentoringModel;
 import net.skhu.mentoring.repository.AccountRepository;
 import net.skhu.mentoring.repository.AvailableTimeRepository;
 import net.skhu.mentoring.repository.DepartmentRepository;
 import net.skhu.mentoring.repository.ProfileRepository;
 import net.skhu.mentoring.service.interfaces.ResourceService;
 import net.skhu.mentoring.vo.AvailableTimeVO;
+import net.skhu.mentoring.vo.BriefAccountVO;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
 import java.util.Collections;
 import java.util.Comparator;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
@@ -55,6 +59,31 @@ public class ResourceServiceImpl implements ResourceService {
     }
 
     @Override
+    public Map<String, List<AvailableTimeVO>> fetchEachMentoringAvailableTimes(final MentoringModel mentoringModel) {
+        Map<String, List<AvailableTimeVO>> mentoringMap = new HashMap<>();
+        Optional<Account> account = accountRepository.findByIdentity(mentoringModel.getMento());
+        if(account.isPresent()){
+            mentoringMap.put(String.format("%s[멘토]", account.get().getName()),
+                    availableTimeRepository.findByAccount(account.get()).stream()
+                        .map(timetable -> AvailableTimeVO.builtToVO(timetable))
+                        .sorted(Comparator.comparingInt(AvailableTimeVO::getDayOrdinal))
+                        .collect(Collectors.toList()));
+
+            for(String menti : mentoringModel.getMentis()){
+                Optional<Account> mentiAccount = accountRepository.findByIdentity(menti);
+                if(mentiAccount.isPresent()){
+                    mentoringMap.put(String.format("%s[멘티]", mentiAccount.get().getName()),
+                            availableTimeRepository.findByAccount(mentiAccount.get()).stream()
+                                    .map(timetable -> AvailableTimeVO.builtToVO(timetable))
+                                    .sorted(Comparator.comparingInt(AvailableTimeVO::getDayOrdinal))
+                                    .collect(Collectors.toList()));
+                }
+            }
+            return mentoringMap;
+        } else return null;
+    }
+
+    @Override
     public Profile fetchEachProfile(final String identity) {
         Optional<Account> account = accountRepository.findByIdentity(identity);
         if (account.isPresent()) {
@@ -69,6 +98,15 @@ public class ResourceServiceImpl implements ResourceService {
         if (account.isPresent()) {
             Account tmpAccount = account.get();
             return tmpAccount.getName();
+        } else return null;
+    }
+
+    @Override
+    public BriefAccountVO fetchBriefAccountInfoByIdentity(String identity) {
+        Optional<Account> account = accountRepository.findByIdentity(identity);
+        if (account.isPresent()) {
+            Account tmpAccount = account.get();
+            return BriefAccountVO.builtToAccountVO(tmpAccount, tmpAccount.getType(), tmpAccount.getDepartment() != null ? tmpAccount.getDepartment().getName() : "");
         } else return null;
     }
 }

--- a/AccountAPI/src/main/java/net/skhu/mentoring/service/interfaces/AdminService.java
+++ b/AccountAPI/src/main/java/net/skhu/mentoring/service/interfaces/AdminService.java
@@ -15,5 +15,7 @@ public interface AdminService {
     List<BriefAccountVO> fetchAccountListWithPagination(final Principal principal, final HttpServletRequest request, final AccountPagination accountPagination);
     ResponseEntity<?> fetchAccountView(final Principal principal, final HttpServletRequest request, final Long id);
     ResponseEntity<?> executeAppointChairman(final Principal principal, final HttpServletRequest request, final Long id);
+    ResponseEntity<?> executeAppointMentoring(final Principal principal, final HttpServletRequest request, final String userId, final String method);
+    ResponseEntity<?> executeResettingStudentStatus(final Principal principal, final HttpServletRequest request);
     ResponseEntity<?> executeReleaseChairman(final Principal principal, final HttpServletRequest request, final Long id);
 }

--- a/AccountAPI/src/main/java/net/skhu/mentoring/service/interfaces/ResourceService.java
+++ b/AccountAPI/src/main/java/net/skhu/mentoring/service/interfaces/ResourceService.java
@@ -2,14 +2,19 @@ package net.skhu.mentoring.service.interfaces;
 
 import net.skhu.mentoring.domain.Department;
 import net.skhu.mentoring.domain.Profile;
+import net.skhu.mentoring.model.MentoringModel;
 import net.skhu.mentoring.vo.AvailableTimeVO;
+import net.skhu.mentoring.vo.BriefAccountVO;
 
 import java.util.List;
+import java.util.Map;
 
 public interface ResourceService {
     boolean fetchExistAccount(final String identity);
     List<Department> fetchAllDepartments();
     List<AvailableTimeVO> fetchEachAvailableTimes(final String identity);
+    Map<String, List<AvailableTimeVO>> fetchEachMentoringAvailableTimes(final MentoringModel mentoringModel);
     Profile fetchEachProfile(final String identity);
     String fetchAccountNameByIdentity(final String identity);
+    BriefAccountVO fetchBriefAccountInfoByIdentity(final String identity);
 }

--- a/MentoAPI/src/main/java/net/skhu/mentoring/model/ScheduleModel.java
+++ b/MentoAPI/src/main/java/net/skhu/mentoring/model/ScheduleModel.java
@@ -12,12 +12,13 @@ import java.time.LocalTime;
 @NoArgsConstructor
 @AllArgsConstructor
 public class ScheduleModel {
+    private Long teamId;
     private LocalDate classDate;
     private LocalTime startTime;
     private LocalTime endTime;
     private String method;
 
     public static ScheduleModel builtToVO(Schedule schedule){
-        return new ScheduleModel(schedule.getStartDate().toLocalDate(), schedule.getStartDate().toLocalTime(), schedule.getEndDate().toLocalTime(), schedule.getMethod());
+        return new ScheduleModel(schedule.getTeam().getId(), schedule.getStartDate().toLocalDate(), schedule.getStartDate().toLocalTime(), schedule.getEndDate().toLocalTime(), schedule.getMethod());
     }
 }

--- a/MentoAPI/src/main/java/net/skhu/mentoring/repository/ScheduleRepository.java
+++ b/MentoAPI/src/main/java/net/skhu/mentoring/repository/ScheduleRepository.java
@@ -10,6 +10,7 @@ import java.util.List;
 
 @Repository
 public interface ScheduleRepository extends JpaRepository<Schedule, Long> {
+    List<Schedule> findByTeam(Team team);
     List<Schedule> findByTeamAndStatus(Team team, ResultStatus status);
     boolean existsByIdIn(List<Long> id);
     boolean existsByTeam(Team team);

--- a/MentoAPI/src/main/java/net/skhu/mentoring/service/implement_objects/ReportServiceImpl.java
+++ b/MentoAPI/src/main/java/net/skhu/mentoring/service/implement_objects/ReportServiceImpl.java
@@ -32,9 +32,6 @@ public class ReportServiceImpl implements ReportService {
     private TeamRepository teamRepository;
 
     @Autowired
-    private SemesterRepository semesterRepository;
-
-    @Autowired
     private ScheduleRepository scheduleRepository;
 
     @Autowired

--- a/MentoAPI/src/main/java/net/skhu/mentoring/service/implement_objects/ScheduleServiceImpl.java
+++ b/MentoAPI/src/main/java/net/skhu/mentoring/service/implement_objects/ScheduleServiceImpl.java
@@ -47,7 +47,7 @@ public class ScheduleServiceImpl implements ScheduleService {
     public List<ScheduleBriefVO> fetchBriefListByTeamId(final Long teamId) {
         Optional<Team> team = teamRepository.findById(teamId);
         if(team.isPresent()){
-            List<Schedule> schedules = scheduleRepository.findByTeamAndStatus(team.get(), ResultStatus.PERMIT);
+            List<Schedule> schedules = scheduleRepository.findByTeam(team.get());
             return schedules.stream()
                     .map(schedule -> ScheduleBriefVO.builtToVO(schedule))
                     .collect(Collectors.toList());
@@ -125,7 +125,7 @@ public class ScheduleServiceImpl implements ScheduleService {
     public ResponseEntity<String> deleteScheduleByIdList(final List<Long> scheduleIds) {
         if(scheduleRepository.existsByIdIn(scheduleIds)){
             scheduleRepository.deleteByIdIn(scheduleIds);
-            return new ResponseEntity<>("선택하신 수업 시간 목록이 삭제 되었습니다. 스케쥴은 그대로 남아 있으니 이를 토대로 다시 작성하시면 됩니다.", HttpStatus.OK);
+            return new ResponseEntity<>("선택하신 수업 시간 목록이 삭제 되었습니다.", HttpStatus.OK);
         } else return new ResponseEntity<>("선택하신 수업 시간이 존재하지 않습니다. 다시 시도 바랍니다.", HttpStatus.NON_AUTHORITATIVE_INFORMATION);
     }
 

--- a/NoticeAPI/src/main/java/net/skhu/mentoring/rest_controller/CalendarRestController.java
+++ b/NoticeAPI/src/main/java/net/skhu/mentoring/rest_controller/CalendarRestController.java
@@ -27,6 +27,11 @@ public class CalendarRestController {
         return ResponseEntity.ok(calendarService.fetchCalendarSchedules());
     }
 
+    @GetMapping("calendar/current")
+    public ResponseEntity<CalendarVO> fetchCurrentSchedule(){
+        return ResponseEntity.ok(calendarService.fetchCurrentSchedule());
+    }
+
     @PutMapping("calendar/{userId}")
     public ResponseEntity<String> executeUpdateCalendarSchedule(@PathVariable String userId, @RequestBody CalendarModel calendarModel){
         return calendarService.executeUpdatingCalendarSchedule(userId, calendarModel);

--- a/NoticeAPI/src/main/java/net/skhu/mentoring/service/integrate_objects/CalendarServiceImpl.java
+++ b/NoticeAPI/src/main/java/net/skhu/mentoring/service/integrate_objects/CalendarServiceImpl.java
@@ -28,6 +28,12 @@ public class CalendarServiceImpl implements CalendarService {
     }
 
     @Override
+    public CalendarVO fetchCurrentSchedule() {
+        Optional<Calendar> currentCalendar = calendarRepository.findByCurrentCalendar();
+        return currentCalendar.isPresent() ? CalendarVO.builtToVO(currentCalendar.get()) : null;
+    }
+
+    @Override
     @Transactional
     public ResponseEntity<String> executeUpdatingCalendarSchedule(final String userId, final CalendarModel calendarModel) {
         Optional<Calendar> calendar = calendarRepository.findById(calendarModel.getId());

--- a/NoticeAPI/src/main/java/net/skhu/mentoring/service/interfaces/CalendarService.java
+++ b/NoticeAPI/src/main/java/net/skhu/mentoring/service/interfaces/CalendarService.java
@@ -8,5 +8,6 @@ import java.util.List;
 
 public interface CalendarService {
     List<CalendarVO> fetchCalendarSchedules();
+    CalendarVO fetchCurrentSchedule();
     ResponseEntity<String> executeUpdatingCalendarSchedule(final String userId, final CalendarModel calendarModel);
 }


### PR DESCRIPTION
멘토링 기능을 위해 각 API 별로 다음과 같은 기능을 더 추가하였음.

AccountAPI
멘토링 그룹 별 시간표 조회하는 기능 추가.
관리자가 학생들에게 멘토, 멘티 권한을 줄 수 있는 기능 추가.
멘토링 끝나면 모든 학생 권한을 평상시로 돌려주는 기능 추가.

MentoAPI
멘토링 시간 등록 폼에 팀 번호를 부여하여 수정하는 멘토의 유효성 확인 보장 기능 추가.

NoticeAPI
현재 일정에 어떤 기능이 해당 되는가 불러오는 기능 추가. 이는 최종 구현 시 적용시키면 효과적임.